### PR TITLE
Add simple Docker Compose configuration

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,7 @@
+FROM node
+EXPOSE 3000
+
+RUN npm install -g --silent nodal
+
+WORKDIR /usr/src/app
+CMD ["npm", "start"]

--- a/src/config/db.json
+++ b/src/config/db.json
@@ -3,11 +3,11 @@
   "development": {
     "main": {
       "adapter": "postgres",
-      "host": "localhost",
-      "port": "5432",
-      "user": "postgres",
-      "password": "",
-      "database": "nodal_development"
+      "host": "{{= env.DATABASE_HOST }}",
+      "port": "{{= env.DATABASE_PORT }}",
+      "user": "{{= env.DATABASE_USER }}",
+      "password": "{{= env.DATABASE_PASSWORD }}",
+      "database": "{{= env.DATABASE_DB }}"
     }
   },
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,0 +1,19 @@
+web:
+  build: .
+  ports:
+   - "3000:3000"
+  volumes:
+   - .:/usr/src/app
+  links:
+   - db
+  environment:
+   - DATABASE_HOST=db
+   - DATABASE_PORT=5432
+   - DATABASE_USER=nodal
+   - DATABASE_PASSWORD=nodal
+   - DATABASE_DB=nodal_development
+db:
+  image: postgres
+  environment:
+   - POSTGRES_USER=nodal
+   - POSTGRES_PASSWORD=nodal


### PR DESCRIPTION
Here's the start of a PR to add Docker Compose integration as mentioned in #37. To get this working, you'll need to install [Docker](https://docs.docker.com/engine/installation/) and [Docker Compose](https://docs.docker.com/compose/install/). Running `nodal new` will now add the Docker Compose configuration to the generated project.

To start the server in the development environment, run `docker-compose up`. This will take a while the first time since it needs to download the Postgres and Node.js containers. When it's up you'll see the usual log output from running the development server.

Note that if you want to run any commands which modify the database, you'll have to run them in the container. For example:

`docker-compose run web nodal db:create`

As mentioned in the original issue, there's still the outstanding issue of how to manage configuration. I'm personally in favour of not having separate sections in the configuration file for development and production and just using environment variables for everything. For this first pass I just copied the production DB config over to development.