### PR TITLE
Uses cross-spawn-async for Windows compatibility

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -106,13 +106,13 @@
           )(promptResult));
 
 
-          let spawn = require('child_process').spawn;
+          let spawn = require('cross-spawn-async');
 
-          let child = spawn('npm', ['cache', 'clean'], {cwd: process.cwd() + '/' + dirname, stdio: [process.stdin, process.stdout, process.stderr]});
+          let child = spawn('npm', ['cache', 'clean'], {cwd: process.cwd() + '/' + dirname, stdio: 'inherit'});
 
           child.on('exit', function() {
 
-            let child = spawn('npm',  ['install'], {cwd: process.cwd() + '/' + dirname, stdio: [process.stdin, process.stdout, process.stderr]});
+            let child = spawn('npm',  ['install'], {cwd: process.cwd() + '/' + dirname, stdio: 'inherit'});
 
             console.log('Installing packages in this directory...');
             console.log('');
@@ -175,8 +175,8 @@
       _: function(args, flags) {
 
         let Nodal = require('../core/module.js');
-        let spawn = require('child_process').spawn;
-        let child = spawn('npm',  ['start'], {stdio: [process.stdin, process.stdout, process.stderr]});
+        let spawn = require('cross-spawn-async');
+        let child = spawn('npm',  ['start'], {stdio: 'inherit'});
 
         process.on('exit', function() {
           child && child.kill();

--- a/cli/generate/model.js
+++ b/cli/generate/model.js
@@ -145,8 +145,8 @@ module.exports = (function() {
         console.log('Installing additional packages in this directory...');
         console.log('');
 
-        let spawn = require('child_process').spawn;
-        let child = spawn('npm',  ['install', 'bcrypt', '--save'], {cwd: process.cwd(), stdio: [process.stdin, process.stdout, process.stderr]});
+        let spawn = require('cross-spawn-async');
+        let child = spawn('npm',  ['install', 'bcrypt', '--save'], {cwd: process.cwd(), stdio: 'inherit'});
 
         child.on('exit', function() {
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "any-db-transaction": "~2.2.2",
     "async": "~0.9.0",
     "colors": "~1.1.0",
+    "cross-spawn-async": "~2.1.6",
     "dot": "~1.0.3",
     "http-proxy": "~1.11.1",
     "i": "~0.3.3",

--- a/test/runner.js
+++ b/test/runner.js
@@ -10,56 +10,56 @@ describe('Test Suite', function() {
   let Nodal = require('../core/module.js');
   Nodal.rootDirectory = __dirname;
   
-  // `psql` can take a long time to respond to a request on Windows
-  // Here we pass a ~15 seconds timeout to allow for the
-  // child process to exit gracefully or timeout.
-  let processOptions = {
-    timeout: 14900
-  };
-  
-  let commandTable = {
-    "drop": 'psql -c \'drop database if exists nodal_test;\' -U postgres',
-    "create": "psql -c \'create database nodal_test;\' -U postgres",
-    "WIN32": {
-      "drop": 'psql -q -c "drop database if exists nodal_test;" -U postgres',
-      "create": 'psql -a -c "create database nodal_test;" -U postgres'
-    }
-  };
-  
-  let getOSCommand = function (command) {
-    if(os.platform() === 'win32') {
-      return commandTable.WIN32[command];
-    }else{
-      return commandTable[command];
-    }
-  };
+  if(os.platform() === 'win32') {
+    // `psql` can take a long time to respond to a request on Windows
+    // Here we pass a ~15 seconds timeout to allow for the
+    // child process to exit gracefully or timeout.
+    let processOptions = {
+      timeout: 14900
+    };
+    
+    before(function(done) {
+      this.timeout(30000); // Set timeout to 30 seconds
+      if (global.env === 'development') {
+        // Using async exec here to easily handler stderr
+        // Errors are not thrown and instead are treated as warnings
+        child_process.exec('psql -q -c "drop database if exists nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+          if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
+          // 
+          child_process.exec('psql -a -c "create database nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+            if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
+            done();
+          });
+        });
+      }
+    });
 
-  before(function(done) {
-    this.timeout(30000); // Set timeout to 30 seconds
-    if (global.env === 'development') {
-      // Using async exec here to easily handler stderr
-      // Errors are not thrown and instead are treated as warnings
-      child_process.exec(getOSCommand("drop"), processOptions, function(error, stdout, stderr) {
-        if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
-        // 
-        child_process.exec(getOSCommand("create"), processOptions, function(error, stdout, stderr) {
+    after(function(done) {
+      this.timeout(30000); // Set timeout to 30 seconds
+      if (global.env === 'development') {
+        // Don't remove the -q option, it will break the db connection pool
+        child_process.exec('psql -q -c "drop database if exists nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
           if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
           done();
         });
-      });
-    }
-  });
+      }
+    });
+  }else{
+    before(function() {
+      if (global.env === 'development') {
+        // child_process.execSync('createuser postgres -s -q');
+        child_process.execSync('psql -c \'drop database if exists nodal_test;\' -U postgres');
+        child_process.execSync('psql -c \'create database nodal_test;\' -U postgres');
+      }
+    });
 
-  after(function(done) {
-    this.timeout(30000); // Set timeout to 30 seconds
-    if (global.env === 'development') {
-      // Don't remove the -q option, it will break the db connection pool
-      child_process.exec(getOSCommand("drop"), processOptions, function(error, stdout, stderr) {
-        if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
-        done();
-      });
-    }
-  });
+    after(function() {
+      if (global.env === 'development') {
+        child_process.execSync('psql -c \'drop database if exists nodal_test;\' -U postgres');
+      }
+    });
+  }
+  
 
   require('./tests/nodal.js')(Nodal);
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,6 +1,7 @@
 "use strict";
 
 let child_process = require('child_process');
+let os = require('os');
 
 global.env = process.env.NODE_ENV || 'development';
 
@@ -15,16 +16,33 @@ describe('Test Suite', function() {
   let processOptions = {
     timeout: 14900
   };
+  
+  let commandTable = {
+    "drop": 'psql -c \'drop database if exists nodal_test;\' -U postgres',
+    "create": "psql -c \'create database nodal_test;\' -U postgres",
+    "WIN32": {
+      "drop": 'psql -q -c "drop database if exists nodal_test;" -U postgres',
+      "create": 'psql -a -c "create database nodal_test;" -U postgres'
+    }
+  };
+  
+  let getOSCommand = function (command) {
+    if(os.platform() === 'win32') {
+      return commandTable.WIN32[command];
+    }else{
+      return commandTable[command];
+    }
+  };
 
   before(function(done) {
     this.timeout(30000); // Set timeout to 30 seconds
     if (global.env === 'development') {
       // Using async exec here to easily handler stderr
       // Errors are not thrown and instead are treated as warnings
-      child_process.exec('psql -a -c "drop database if exists nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+      child_process.exec(getOSCommand("drop"), processOptions, function(error, stdout, stderr) {
         if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
         // 
-        child_process.exec('psql -a -c "create database nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+        child_process.exec(getOSCommand("create"), processOptions, function(error, stdout, stderr) {
           if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
           done();
         });
@@ -36,7 +54,7 @@ describe('Test Suite', function() {
     this.timeout(30000); // Set timeout to 30 seconds
     if (global.env === 'development') {
       // Don't remove the -q option, it will break the db connection pool
-      child_process.exec('psql -q -c "drop database if exists nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+      child_process.exec(getOSCommand("drop"), processOptions, function(error, stdout, stderr) {
         if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
         done();
       });

--- a/test/runner.js
+++ b/test/runner.js
@@ -8,18 +8,38 @@ describe('Test Suite', function() {
 
   let Nodal = require('../core/module.js');
   Nodal.rootDirectory = __dirname;
+  
+  // `psql` can take a long time to respond to a request on Windows
+  // Here we pass a ~15 seconds timeout to allow for the
+  // child process to exit gracefully or timeout.
+  let processOptions = {
+    timeout: 14900
+  };
 
-  before(function() {
+  before(function(done) {
+    this.timeout(30000); // Set timeout to 30 seconds
     if (global.env === 'development') {
-      // child_process.execSync('createuser postgres -s -q');
-      child_process.execSync('psql -c \'drop database if exists nodal_test;\' -U postgres');
-      child_process.execSync('psql -c \'create database nodal_test;\' -U postgres');
+      // Using async exec here to easily handler stderr
+      // Errors are not thrown and instead are treated as warnings
+      child_process.exec('psql -a -c "drop database if exists nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+        if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
+        // 
+        child_process.exec('psql -a -c "create database nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+          if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
+          done();
+        });
+      });
     }
   });
 
-  after(function() {
+  after(function(done) {
+    this.timeout(30000); // Set timeout to 30 seconds
     if (global.env === 'development') {
-      child_process.execSync('psql -c \'drop database if exists nodal_test;\' -U postgres');
+      // Don't remove the -q option, it will break the db connection pool
+      child_process.exec('psql -q -c "drop database if exists nodal_test;" -U postgres', processOptions, function(error, stdout, stderr) {
+        if(error) console.warn("Warning:", stderr, "\nErrors ignored.");
+        done();
+      });
     }
   });
 


### PR DESCRIPTION
Replaced `child_process.spawn` with `cross-spawn-async` for cross-platform
compatibility. (Windows command line has problems with
`child_process.spawn`.)