### PR TITLE
Implements a help CLI command - `nodal help`

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -16,10 +16,60 @@
 
   command = command ? command : '_';
   command = {name: command.split(':')[0], value: command.split(':')[1] || '_'};
+  
+  let commandDefinitions = {
+      "new": "Initialize the current directory as a new Nodal project",
+      "s": "Start the Nodal server based on the current project",
+      "db:create": "Create a new PostgreSQL database for the current project",
+      "db:prepare": "Prepare the PostgreSQL database",
+      "g:model --<modelname>": "Add a new model",
+      "g:controller <namespace> --for:<modelname>": "Add a new controller for the model",
+      "db:migrate": "Run all pending Database migrations",
+      "db:rollback": "Rollback migrations"
+  };
+  
+  function repeatChar(char, r) {
+    // Repeats a character to create a string
+    // Useful for logging
+    var str = '';
+    for (var i = 0; i < Math.ceil(r); i++) str += char;
+    return str; 
+  }
+  
+  // Check for `nodal help` command
+  if (command.name === 'help') {
+      
+    console.log('');
+    console.log(' Nodal commands');
+    console.log('');
+    
+    let highPad = 0;
+    // Find the longest length
+    for (var keys in commandDefinitions) { if(keys.length > highPad) highPad = keys.length; }
+    for (var cKey in commandDefinitions) {
+      // Extract base command (e.g. `g:model`)
+      let fullCommand = cKey;
+      let padding = '';
+      // Add padding to the end
+      if(fullCommand.length < highPad) padding = repeatChar(' ', highPad - fullCommand.length);
+      
+      // Parse Command to colorize
+      let splitCommand = fullCommand.split(' ');
+      let baseCommand = splitCommand.shift();
+      let tags = splitCommand.join(' ');
+      let definition = commandDefinitions[cKey];
+      
+      console.log(colors.yellow.bold(' nodal ' + baseCommand), (tags)?colors.gray(tags):'', padding, '\t' + definition);
+      console.log(colors.gray(repeatChar('-', highPad + 7)));
+    }
+    process.exit(1);
+    
+  }
 
   if (command.name !== 'new' && !fs.existsSync(process.cwd() + '/.nodal')) {
 
     console.error(colors.red.bold('Error: ') + 'No Nodal project found here. Use `nodal new` to initialize a project.');
+    console.error(colors.green('Help: ') + 'Type `nodal help` to get more information about what Nodal can do for you.');
     process.exit(1);
 
   } else if (command.name === 'new') {

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -22,8 +22,11 @@
       "s": "Start the Nodal server based on the current project",
       "db:create": "Create a new PostgreSQL database for the current project",
       "db:prepare": "Prepare the PostgreSQL database",
-      "g:model --<modelname>": "Add a new model",
-      "g:controller <namespace> --for:<modelname>": "Add a new controller for the model",
+      "g:model --<user>": "Add a new model",
+      "g:model --<access_token>": "Add a new model through access token",
+      "g:model <path_to_model>": "Add a new model from a path",
+      "g:controller <path_to_controller>": "Add a new controller",
+      "g:controller <path_to> --for:<modelname>": "Add a new controller for a model",
       "db:migrate": "Run all pending Database migrations",
       "db:rollback": "Rollback migrations"
   };


### PR DESCRIPTION
Nodal's CLI implementation is lacking a fundamental help command. This command is present in nearly every established command line interface and is recognized by many users. Current implementation can be invoked through `nodal help` (perhaps --help could provide more specific info based on the command) that provides a definition to every publicly available command through an object name `commandDefinitions`. The object itself allows for easy implementation of a definition.

There is a better way of doing this but it requires some major structural changes (every command goes into a separate file). In my experience it is much cleaner to maintain but that is up to your discretion. [Check out the alternative here](https://github.com/schahriar/Galleon/blob/master/bin/startup#L14) and [yargs](https://www.npmjs.com/package/yargs) module might work too.

![Preview](http://i.imgur.com/lFFofus.png?1)

Introduces {Object} commandDefinitions - stores commands and definitions
of all exposed CLI functions
Introduces {Function} repeatChar - repeats a character for CLI purposes