### PR TITLE
Generate db.json using the app name

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -59,6 +59,7 @@
         }
 
         promptResult.simpleName = promptResult.name.replace(/\s/gi, '-');
+        promptResult.databaseName = inflect.underscore(promptResult.name);
         let dirname = promptResult.name.replace(/[^A-Za-z0-9-_]/gi, '-').toLowerCase();
 
         console.log('');
@@ -105,6 +106,11 @@
             fs.readFileSync(__dirname + '/README.md.jst').toString()
           )(promptResult));
 
+          // read in the dbjson template, replace the development database name
+          // generate new config/db.json in the generated app
+          let dbjson = JSON.parse(fs.readFileSync(__dirname + '/templates/db.json'));
+          dbjson.development.main.database = promptResult.databaseName + '_development';
+          fs.writeFileSync('./' + dirname + '/config/db.json', JSON.stringify(dbjson, null, 4));
 
           let spawn = require('child_process').spawn;
 

--- a/cli/templates/db.json
+++ b/cli/templates/db.json
@@ -1,0 +1,26 @@
+{
+
+  "development": {
+    "main": {
+      "adapter": "postgres",
+      "host": "localhost",
+      "port": "5432",
+      "user": "postgres",
+      "password": "",
+      "database": "nodal_development"
+    }
+  },
+
+  "production": {
+    "main": {
+      "adapter": "postgres",
+      "host": "{{= env.DATABASE_HOST }}",
+      "port": "{{= env.DATABASE_PORT }}",
+      "user": "{{= env.DATABASE_USER }}",
+      "password": "{{= env.DATABASE_PASSWORD }}",
+      "database": "{{= env.DATABASE_DB }}",
+      "connectionString": "{{= env.DATABASE_URL }}"
+    }
+  }
+
+}


### PR DESCRIPTION
this generates db.json in the generated app with a development database name based off the app name vs static nodal_development.

doT inline sub-template ended up not being a solution for this (since we still wanted the doT sections for production), so this loads in a template json, replaces dbjson.development.main.database and writes it back to the generated app db.json

this also is the start of a cleanup of cli templates (non nodal g ones) into a subdir

closes #49 