### PR TITLE
Added keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nodal",
   "version": "0.5.6-rc2",
   "description": "An API Server and Framework for node.js",
+  "keywords": ["framework", "api", "application", "branding", "server", "modular", "nodal"],
   "author": "Keith Horwood",
   "main": "core/module.js",
   "dependencies": {


### PR DESCRIPTION
Keywords are important for better indexing for npm search. They use a third-party autocomplete that hooks up to the keywords. Try searching Nodal at npmjs.com and it won't show up in autocomplete input. Added a few to package.json