### PR TITLE
Default index cleanup

### DIFF
--- a/src/app/templates/head.html
+++ b/src/app/templates/head.html
@@ -47,15 +47,23 @@
 
     span.signature {
       display: block;
-      margin-top: 10px;
+      margin-top: 20px;
+    }
+
+    span.file, span.command {
+      font-family: monospace;
+      font-size: 13px;
+      padding: 3px;
+      font-weight: normal;
+
     }
 
     span.file {
-      font-family: monospace;
-      font-size: 13px;
       background-color: #FAF38E;
-      padding: 3px;
-      font-weight: normal;
+    }
+
+    span.command {
+      background-color: #E5E7E7;
     }
 
     ul.steps {

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -22,14 +22,16 @@
           <li>nodal g:controller v1 --for:user</li>
           <li>nodal db:migrate</li>
         </ul>
-        <span>To get a good feeling about how Nodal works and its intended use. :)</span>
+        <span>To get a good feeling about how Nodal works and its intended use.</span>
+        <br/>
+        <br/>
+        <span>You can see all of the built in nodal commands by running <span class="command">nodal help</span></span>
         <br/>
         <br/>
         <strong>Important Note:</strong>
         <br/>
-        <span>Make sure you have Postgres installed, this.useDatabase and your
-          database imports are uncommented in <span class="file">./app/app.js</span>, and your login
-          credentials are correct!</span>
+        <span>For database usage, please make sure you have Postgres installed. You must also uncomment <span class="command">this.useDatabase</span> and the
+          database import in <span class="file">./app/app.js</span>. Please also check to make sure your database credentials are correct in <span class="file">./config/db.json</span></span>
         <span class="signature">- Happy Developing!</span>
       </div>
     </div>


### PR DESCRIPTION
Small change to cleanup the wording at the bottom of the default index template regarding enabling database support. Also adds a reference to `nodal help` to see full list of commands