### PR TITLE
Fix select generation when subquery is null like db:migrate

### DIFF
--- a/core/required/db/adapter.js
+++ b/core/required/db/adapter.js
@@ -156,12 +156,11 @@ module.exports = (function() {
     }
 
     generateSelectQuery(subQuery, table, columns, multiFilter, joinArray, orderObjArray, limitObj, paramOffset) {
-
       let formatTableField = (table, column) => `${this.escapeField(table)}.${this.escapeField(column)}`;
 
       if (typeof subQuery === 'object' && subQuery !== null) {
         subQuery = this.escapeField(subQuery.table);
-      } else {
+      } else if (subQuery !== null ){
         subQuery = `(${subQuery})`;
       }
 


### PR DESCRIPTION
Fix blocker in master where adapter#generateSelectQuery could generate invalid query when subQuery was null. I found this as it broke `nodal db:migrate`

Fixes #67 