### PR TITLE
Start of adding higher level cli commands, adds new db:bootstrap

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -30,7 +30,7 @@
       "g:middleware <path_to_middleware>": "Add a new middleware",
       "g:task <task name>": "Add a new task",
       "db:migrate": "Run all pending Database migrations",
-      "db:rollback": "Rollback migrations"
+      "db:rollback": "Rollback migrations",
       "db:bootstrap": "Runs db:prepare and db:migrate in a single command"
   };
 

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -214,7 +214,7 @@
   let generateCommands = require('./generate/commands.js');
 
   // bind the db funcs so that they can call each other
-  Object.keys(dbCommands).forEach( (f) => {
+  Object.keys(dbCommands).forEach((f) => {
     dbCommands[f] = dbCommands[f].bind(dbCommands);
   });
 

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -31,6 +31,7 @@
       "g:task <task name>": "Add a new task",
       "db:migrate": "Run all pending Database migrations",
       "db:rollback": "Rollback migrations"
+      "db:bootstrap": "Runs db:prepare and db:migrate in a single command"
   };
 
   function repeatChar(char, r) {
@@ -212,6 +213,11 @@
   let dbCommands = require('./db/commands.js');
   let generateCommands = require('./generate/commands.js');
 
+  // bind the db funcs so that they can call each other
+  Object.keys(dbCommands).forEach( (f) => {
+    dbCommands[f] = dbCommands[f].bind(dbCommands);
+  });
+
   let args = [];
   let flags = {};
 
@@ -255,7 +261,8 @@
       prepare: dbCommands.prepare,
       migrate: dbCommands.migrate,
       rollback: dbCommands.rollback,
-      version: dbCommands.version
+      version: dbCommands.version,
+      bootstrap: dbCommands.bootstrap
     },
     g: {
       _: function(args, flags) {

--- a/cli/db/commands.js
+++ b/cli/db/commands.js
@@ -340,7 +340,7 @@ module.exports = {
           console.error(colors.red.bold('ERROR: ') + err.message);
           console.log('Database bootstrap could not be completed');
         } else {
-          console.log('Migration bootstrap complete!');
+          console.log('Database bootstrap complete!');
         }
         process.exit(0);
 

--- a/cli/db/commands.js
+++ b/cli/db/commands.js
@@ -13,11 +13,15 @@ let colors = require('colors/safe');
 let MODEL_PATH = './app/models';
 let MIGRATION_PATH = './db/migrations';
 
-function errorHandler(err) {
+function errorHandler(err, callback) {
 
   if (err) {
     console.error(colors.red.bold('ERROR: ') + err.message);
-    process.exit(0);
+    if ( undefined === callback) {
+      process.exit(0);
+    } else {
+      callback(err)
+    }
   }
 
   return true;
@@ -106,8 +110,7 @@ module.exports = {
 
   },
 
-  prepare: function() {
-
+  prepare: function(args, flags, callback) {
     let dbCredentials = Nodal.my.Config.db.main;
 
     let db = new Database();
@@ -128,8 +131,11 @@ module.exports = {
         errorHandler(err);
         Database.prototype.info('Prepared database "' + dbCredentials.database + '" for migrations');
         schema.save();
-        process.exit(0);
-
+        if ( undefined === callback) {
+          process.exit(0);
+        } else {
+          callback();
+        }
       }
     );
 
@@ -170,7 +176,7 @@ module.exports = {
 
   },
 
-  migrate: function(args, flags) {
+  migrate: function(args, flags, callback) {
 
     let dbCredentials = Nodal.my.Config.db.main;
 
@@ -184,7 +190,11 @@ module.exports = {
 
       if (err) {
         db.error('Could not get schema migrations, try `nodal db:prepare` first');
-        process.exit(0);
+        if ( undefined === callback) {
+          process.exit(0);
+        } else {
+          callback(err);
+        }
       }
 
       let schema_ids = result.rows.map(function(v) { return v.id; });
@@ -202,7 +212,11 @@ module.exports = {
 
       if (migrations.length === 0) {
         console.log('No pending migrations');
-        process.exit(0);
+        if ( undefined === callback) {
+          process.exit(0);
+        } else {
+          callback();
+        }
       }
 
       let migrateFuncs = migrations.map(function(v) {
@@ -230,7 +244,11 @@ module.exports = {
             console.log('Migration complete!');
           }
 
-          process.exit(0);
+          if ( undefined === callback) {
+            process.exit(0);
+          } else {
+            callback(err);
+          }
 
         }
       );
@@ -301,6 +319,33 @@ module.exports = {
 
     });
 
+  },
+
+  // db:bootstrap executes db:prepare and db:migrate in a single command. This
+  // is really helpful for things like web auto deploy to heroku of a sample
+  // application
+  // TODO: Integrate db:seed when its implemented
+  bootstrap: function(args, flags) {
+
+    async.series([
+        (callback) => {
+          this.prepare(args, flags, callback);
+        },
+        (callback) => {
+          this.migrate(args, flags, callback);
+        }
+      ],
+      function(err) {
+        if (err) {
+          console.error(colors.red.bold('ERROR: ') + err.message);
+          console.log('Database bootstrap could not be completed');
+        } else {
+          console.log('Migration bootstrap complete!');
+        }
+        process.exit(0);
+
+      }
+    );
   }
 
 };


### PR DESCRIPTION
See #50 for root rational

This commit adds callback support to the prepare and migrate commands and adds a new `nodal db:bootstrap` that will run prepare and migrate as a single command.

NOTE: I went with if's for the callback check vs ternary for readability. I really wish node 4.x supported default params behind a harmony flag as a little `callback = process.exit` would have reduced those if  checks


fixes #50 