### PR TITLE
Adds Simple foreign key support

### DIFF
--- a/core/required/db/adapter.js
+++ b/core/required/db/adapter.js
@@ -34,6 +34,9 @@ module.exports = (function() {
     generateCreateIndex(table, columnName, indexType) {}
     generateDropIndex(table, columnName) {}
 
+    generateSimpleForeignKeyQuery(table, referenceTable) {}
+    generateDropSimpleForeignKeyQuery(table, referenceTable) {}
+
     sanitize(type, value) {
 
       let fnSanitize = this.sanitizeType[type];
@@ -569,6 +572,8 @@ module.exports = (function() {
   DatabaseAdapter.prototype.types = {};
   DatabaseAdapter.prototype.sanitizeType = {};
   DatabaseAdapter.prototype.escapeFieldCharacter = '';
+
+  DatabaseAdapter.prototype.supportsForeignKey = false;
 
   return DatabaseAdapter;
 

--- a/core/required/db/adapters/postgres.js
+++ b/core/required/db/adapters/postgres.js
@@ -1,7 +1,7 @@
-"use strict";
-
 module.exports = (function() {
+  'use strict';
 
+  const inflect = require('i')();
   const DatabaseAdapter = require('../adapter.js');
 
   class PostgresAdapter extends DatabaseAdapter {
@@ -322,6 +322,30 @@ module.exports = (function() {
 
     }
 
+    generateSimpleForeignKeyQuery(table, referenceTable) {
+      return [
+        'ALTER TABLE',
+          this.escapeField(table),
+        'ADD CONSTRAINT',
+          `${this.generateConstraint(table, referenceTable, 'id_fk')}`,
+        'FOREIGN KEY',
+          `(${this.escapeField(`${inflect.singularize(referenceTable)}_id`)})`,
+        'REFERENCES',
+          `${this.escapeField(referenceTable)} (${this.escapeField('id')})`
+      ].join(' ');
+
+    }
+
+    generateDropSimpleForeignKeyQuery(table, referenceTable) {
+      return [
+        'ALTER TABLE',
+          this.escapeField(table),
+        'DROP CONSTRAINT IF EXISTS',
+          `${this.generateConstraint(table, referenceTable, 'id_fk')}`,
+      ].join(' ');
+
+    }
+
     generateRenameSequenceQuery(table, columnName, newTable, newColumnName) {
 
       return [
@@ -417,6 +441,8 @@ module.exports = (function() {
       dbName: 'BOOLEAN'
     }
   };
+
+  PostgresAdapter.prototype.supportsForeignKey = true;
 
   return PostgresAdapter;
 

--- a/core/required/db/migration.js
+++ b/core/required/db/migration.js
@@ -166,18 +166,23 @@ module.exports = (function() {
 
     addForeignKey(table, referenceTable) {
 
-      this.schema.addForeignKey(table, referenceTable);
-
-      return this.db.adapter.generateSimpleForeignKeyQuery(table, referenceTable);
+      if (this.db.adapter.supportsForeignKey) {
+        this.schema.addForeignKey(table, referenceTable);
+        return this.db.adapter.generateSimpleForeignKeyQuery(table, referenceTable);
+      } else {
+        throw new Error(`${this.db.adapter.constructor.name} does not support foreign keys`);
+      }
 
     }
 
     dropForeignKey(table, referenceTable) {
 
-      this.schema.dropForeignKey(table, referenceTable);
-
-      return this.db.adapter.generateDropSimpleForeignKeyQuery(table, referenceTable);
-
+      if (this.db.adapter.supportsForeignKey) {
+        this.schema.dropForeignKey(table, referenceTable);
+        return this.db.adapter.generateDropSimpleForeignKeyQuery(table, referenceTable);
+      } else {
+        throw new Error(`${this.db.adapter.constructor.name} does not support foreign keys`);
+      }
     }
 
 

--- a/core/required/db/migration.js
+++ b/core/required/db/migration.js
@@ -164,6 +164,23 @@ module.exports = (function() {
 
     }
 
+    addForeignKey(table, referenceTable) {
+
+      this.schema.addForeignKey(table, referenceTable);
+
+      return this.db.adapter.generateSimpleForeignKeyQuery(table, referenceTable);
+
+    }
+
+    dropForeignKey(table, referenceTable) {
+
+      this.schema.dropForeignKey(table, referenceTable);
+
+      return this.db.adapter.generateDropSimpleForeignKeyQuery(table, referenceTable);
+
+    }
+
+
   };
 
   return Migration;

--- a/core/required/db/schema_generator.js
+++ b/core/required/db/schema_generator.js
@@ -319,6 +319,40 @@ module.exports = (function() {
 
     }
 
+    addForeignKey(table, referenceTable) {
+
+      let tableClass = inflect.classify(table);
+      let referenceTableClass = inflect.classify(referenceTable);
+
+      if (!this.models[tableClass]) {
+        throw new Error(`Model ${tableClass} does not exist.`);
+      }
+
+      if (!this.models[referenceTableClass]) {
+        throw new Error(`Model ${referenceTableClass} does not exist.`);
+      }
+
+      return true;
+
+    }
+
+    dropForeignKey(table, referenceTable) {
+
+      let tableClass = inflect.classify(table);
+      let referenceTableClass = inflect.classify(referenceTable);
+
+      if (!this.models[tableClass]) {
+        throw new Error(`Model ${tableClass} does not exist.`);
+      }
+
+      if (!this.models[referenceTableClass]) {
+        throw new Error(`Model ${referenceTableClass} does not exist.`);
+      }
+
+      return true;
+
+    }
+
     read(json) {
       return this.set(JSON.parse(json));
     }


### PR DESCRIPTION
Adds  simple addForeignKey and dropForeignKey support to migrations. It does not dump the constraints to the schema or support defining the fk on a createTable. It ensures the models exist before running, but that is it for validation.