### PR TITLE
Adds an task to src/ for generated apps to generate db/seed.json

### DIFF
--- a/src/tasks/regenerate_seed.js
+++ b/src/tasks/regenerate_seed.js
@@ -1,0 +1,42 @@
+module.exports = (function() {
+
+    'use strict';
+
+    const Nodal = require('nodal');
+    const fs = require('fs');
+    const async = require('async');
+    const inflect = require('i')();
+
+    class GenerateSeedTask {
+
+      exec(app, args, callback) {
+
+        let seed = {};
+
+        let tasks = Object.keys(Nodal.my.Schema.models).map((model) = > {
+
+          return (callback) = > {
+            let seedKey = inflect.underscore(inflect.classify(model));
+            let modelObject = Nodal.require(`./app/models/${seedKey}.js`);
+
+            modelObject.query().where({}).end((err, models) = > {
+              seed[model] = models.toObject();
+              callback();
+            });
+
+          };
+
+        })
+
+        async.series(tasks, (err) = > {
+          fs.writeFileSync('./db/seed.json', JSON.stringify(seed));
+          console.log('GenerateSeed task executed');
+          callback();
+        });
+
+      }
+    }
+
+    return GenerateSeedTask;
+
+})();


### PR DESCRIPTION
This task will re-generate `db/seed.json` based on the application models and existing data in the database. This task will load all models via `Nodal.my.Schema.models` (ie: `db/schema.json`) and then query all rows from each model from the database. All data will be written to `db/seed.json`

**Running:**  `nodal task regenerate_seed`

NOTES:
* This uses the current format of `db/seed.json`
* Does not exclude columns (like passwords)
* Dumps all data and all columns
* Forcibly overwrites `db/seed.json`

REMINDER: This becomes part of the generated app so you will need to `nodal new`, add some models and data to test
