### PR TITLE
Fix nodal help alignment

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -66,7 +66,8 @@
           if(command.full().length > highPad) highPad = command.full().length;
           // Start at 1 to skip above
           for(let i = 1; i < command.extLength(); i++) {
-            if(command.ext(i).length > highPad) highPad = command.ext(i).split('#')[0].length + command.full().split(' ')[0].length;
+            let extLength = command.ext(i).split('#')[0].length + command.full().split(' ')[0].length;
+            if((command.ext(i).length > highPad) && extLength > highPad) highPad = extLength;
           }
         });
 


### PR DESCRIPTION
If the extended command (command.ext) was longer than current highPad, when resetting highPad to ext length after splitting on # and ' ', the result could be smaller than current highPad. This fixes makes sure both are greater before changing highPad

cc: @schahriar 