### PR TITLE
Postgres JSONB Support with Match and Existence Comparators

### DIFF
--- a/LEARN.md
+++ b/LEARN.md
@@ -368,6 +368,66 @@ query
   });
 ```
 
+## Postgres JSONB Column Type support
+
+Nodal has basic support for the Postgres [JSONB data type](http://www.postgresql.org/docs/9.4/static/datatype-json.html). Any model that has a json column that contains a valid JSON object will have the object automatically marshalled in and out of the database. Let's walk through how to setup and use a model with a json column.
+
+First, lets generate a new model
+
+```nodal g:model Recipe name:string, flags:json```
+
+Open the migration that was generated and you will see the following in the `up()` method.
+
+```javascript
+this.createTable("recipes", [{"name":"name","type":"string,"},{"name":"flags","type":"json"}])
+```
+Let's modify the up command to add an index on the json column. Your `up()` method should look something like this
+
+```javascript    
+up() {
+
+  return [
+    this.createTable("recipes", [{"name":"name","type":"string,"},{"name":"flags","type":"json"}])
+    this.createIndex("recipes", "flags", "gin")
+  ];
+
+}
+```
+
+Nodal provides two comparator's for querying the json data for matches or existence. Lets assume our Recipe table contains a collection of recipes, and the flags json column contains flags related to dietary restrictions like vegetarian, vegan or paleo. Lets query for recipes that are Paleo only
+
+```javascript
+Recipe.query()
+      .where({flags__json:{ paleo: true }})
+      .end( (err,recipes) => {
+        ......
+      });
+```
+
+The `__json` comparator also allows for multi key queries:
+
+```javascript
+Recipe.query()
+      .where({flags__json:{ vegan: true, paleo: true }})
+      .end( (err,recipes) => {
+        ......
+      });
+```
+
+
+
+
+What if you want to query for all recipes that contain a certain key.
+
+```javascript
+Recipe.query()
+      .where({flags__jsoncontains: 'paleo'})
+      .end( (err,recipes) => {
+        ......
+      });
+```
+
+
 ## What Now?
 
 There's still a bunch more to cover! Information on in-depth Migrations, Initializers,

--- a/core/required/db/adapter.js
+++ b/core/required/db/adapter.js
@@ -353,6 +353,10 @@ module.exports = (function() {
 
     }
 
+    preprocessWhereObj(table, whereObj) {
+      return whereObj;
+    }
+
     parseWhereObj(table, whereObj) {
 
       return whereObj.map((where, i) => {
@@ -375,6 +379,7 @@ module.exports = (function() {
       return whereObjArray
         .filter(v => v)
         .sort((a, b) => a.joined === b.joined ? a.table > b.table : a.joined > b.joined) // important! must be sorted.
+        .map(v => this.preprocessWhereObj(table, v))
         .map(v => this.parseWhereObj(table, v));
 
     }
@@ -413,7 +418,7 @@ module.exports = (function() {
 
         if (!joined) {
 
-          clauses.push(comparators[whereObj.comparator](whereObj.refName));
+          clauses.push(comparators[whereObj.comparator](whereObj.refName, whereObj.value));
 
         } else {
 
@@ -433,7 +438,7 @@ module.exports = (function() {
 
           }
 
-          currentJoinedClauses.push(comparators[whereObj.comparator](whereObj.refName));
+          currentJoinedClauses.push(comparators[whereObj.comparator](whereObj.refName, whereObj.value));
 
         }
 
@@ -598,6 +603,8 @@ module.exports = (function() {
     not_null: true
   };
 
+  DatabaseAdapter.prototype.documentTypes = [];
+
   DatabaseAdapter.prototype.aggregates = {
     'sum': field => `SUM(${field})`,
     'avg': field => `AVG(${field})`,
@@ -616,6 +623,8 @@ module.exports = (function() {
   DatabaseAdapter.prototype.types = {};
   DatabaseAdapter.prototype.sanitizeType = {};
   DatabaseAdapter.prototype.escapeFieldCharacter = '';
+  DatabaseAdapter.prototype.columnDepthDelimiter = '';
+  DatabaseAdapter.prototype.whereDepthDelimiter = '';
 
   DatabaseAdapter.prototype.supportsForeignKey = false;
 

--- a/core/required/db/adapters/postgres.js
+++ b/core/required/db/adapters/postgres.js
@@ -3,6 +3,7 @@ module.exports = (function() {
 
   const inflect = require('i')();
   const DatabaseAdapter = require('../adapter.js');
+  const utilities = require('../../utilities.js');
 
   class PostgresAdapter extends DatabaseAdapter {
 
@@ -404,7 +405,7 @@ module.exports = (function() {
 
       let whereObjArray = []
       whereObj.forEach( where => {
-        if (typeof where.value === 'object' && Object.keys(where.value).length ) {
+        if (utilities.isObject(where.value)) {
           Object.keys(where.value).map( (k) => {
             whereObjArray.push(Object.assign({}, where, {
               columnName: `${where.columnName}${this.whereDepthDelimiter}'${k}'`,

--- a/core/required/db/data_types.js
+++ b/core/required/db/data_types.js
@@ -48,6 +48,11 @@ module.exports = (function() {
       convert: function(v) {
         return typeof v === 'string' ? [true, false][({'f':1,'false':1,'n':1,'no':1,'off':1,'0':1,'':1}[v]|0)] : !!v;
       }
+    },
+    json: {
+      convert: function(v) {
+        return typeof v === 'string' ? JSON.parse(v) : v;
+      }
     }
   };
 

--- a/core/required/db/schema_generator.js
+++ b/core/required/db/schema_generator.js
@@ -304,7 +304,7 @@ module.exports = (function() {
       if (this.indices.filter(function(v) {
         return v.table === table && v.column === column;
       }).length) {
-        throw new Error('Index already exists on column "' + column + '" of table "' + table + '"');
+        throw new Error(`Index already exists on column "${column}" of table "${table}"`);
       }
 
       this.indices.push({table: table, column: column, type: type});

--- a/core/required/model.js
+++ b/core/required/model.js
@@ -11,6 +11,7 @@ module.exports = (function() {
   const utilities = require('./utilities.js');
   const async = require('async');
   const inflect = require('i')();
+  const deepEqual = require('deep-equal');
 
   const RelationshipGraph = require('./relationship_graph.js');
   const Relationships = new RelationshipGraph();
@@ -642,8 +643,15 @@ module.exports = (function() {
               break;
             }
           }
-
         }
+
+        // If we have an object value (json), do a deterministic diff using
+        // node-deep-equals
+        // NOTE: Lets do an extra deep object test
+        if ( utilities.isObject(value) ) {
+          changed = !deepEqual( curValue, value, { strict: true});
+        }
+
       }
 
       this._data[field] = value;

--- a/core/required/utilities.js
+++ b/core/required/utilities.js
@@ -13,6 +13,11 @@ module.exports = (function() {
         .replace(/^\(?(.*?)\)?$/g, '$1')
         .split(',')
         .filter(v => !!v);
+    },
+
+    isObject(value) {
+      return typeof value === 'object' &&
+             {}.toString.call(value) === '[object Object]';
     }
 
   };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "async": "~0.9.0",
     "colors": "~1.1.0",
     "cross-spawn-async": "~2.1.6",
+    "deep-equal": "~1.0.1",
     "dot": "~1.0.3",
     "fs-extra": "~0.26.4",
     "http-proxy": "~1.11.1",

--- a/test/tests/composer.js
+++ b/test/tests/composer.js
@@ -62,6 +62,7 @@ module.exports = (function(Nodal) {
         {name: 'parent_id', type: 'int'},
         {name: 'name', type: 'string'},
         {name: 'animal', type: 'string'},
+        {name: 'details', type: 'json'},
         {name: 'created_at', type: 'datetime'},
         {name: 'updated_at', type: 'datetime'}
       ]
@@ -138,7 +139,7 @@ module.exports = (function(Nodal) {
             p.set('children', Nodal.ModelArray.from(children));
 
             let pets = ['Oliver', 'Ruby', 'Pascal'].map((name, i) => {
-              return new Pet({parent_id: id, name: name, animal: ['Cat', 'Dog', 'Cat'][i]});
+              return new Pet({parent_id: id, name: name, animal: ['Cat', 'Dog', 'Cat'][i], details: { language: name === 'Pascal' }});
             });
 
             p.set('pets', Nodal.ModelArray.from(pets));
@@ -896,6 +897,35 @@ module.exports = (function(Nodal) {
 
     });
 
+    it('Should query a pet based on json key existance', (done) => {
+      Pet.query()
+        .where({details__jsoncontains: 'language'})
+        .end((err, pets) => {
+
+            expect(err).to.not.exist;
+            expect(pets.length).to.equal(30);
+            done();
+
+          });
+
+    });
+
+    it('Should query a pet based on json key value', (done) => {
+      Pet.query()
+        .where({details__json: { language: true }})
+        .end((err, pets) => {
+
+            expect(err).to.not.exist;
+            expect(pets.length).to.equal(10);
+            done();
+
+          });
+
+    });
+
+    // IMPORTANT: Do npt place any tests after the `Should do a destroy cascade`
+    // test since all models will be gone
+
     it('Should do a destroy cascade', (done) => {
 
       Parent.query()
@@ -911,6 +941,8 @@ module.exports = (function(Nodal) {
         })
 
     });
+
+
 
   });
 

--- a/test/tests/database.js
+++ b/test/tests/database.js
@@ -29,6 +29,17 @@ module.exports = (function(Nodal) {
     };
 
 
+    let myTableWithJson = {
+      table: 'json_reference',
+      columns: [
+        {name: 'id', type: 'serial'},
+        {name: 'test', type: 'string'},
+        {name: 'content', type: 'json'},
+        {name: 'created_at', type: 'datetime'},
+        {name: 'updated_at', type: 'datetime'}
+      ]
+    };
+
 
     after(function(done) {
 
@@ -114,7 +125,9 @@ module.exports = (function(Nodal) {
         db.transaction(
           [
             db.adapter.generateCreateTableQuery(myTable.table, myTable.columns),
-            db.adapter.generateCreateTableQuery(myReferenceTable.table, myReferenceTable.columns)
+            db.adapter.generateCreateTableQuery(myReferenceTable.table, myReferenceTable.columns),
+            db.adapter.generateCreateTableQuery(myTableWithJson.table, myTableWithJson.columns)
+
           ].join(';'),
           function(err, result) {
             expect(err).to.equal(null);

--- a/test/tests/model.js
+++ b/test/tests/model.js
@@ -14,6 +14,7 @@ module.exports = (function(Nodal) {
         {name: 'id', type: 'serial'},
         {name: 'name', type: 'string'},
         {name: 'age', type: 'int'},
+        {name: 'content', type: 'json'},
         {name: 'created_at', type: 'datetime'},
         {name: 'updated_at', type: 'datetime'}
       ]
@@ -31,6 +32,7 @@ module.exports = (function(Nodal) {
         {name: 'id', type: 'serial'},
         {name: 'material', type: 'string'},
         {name: 'color', type: 'string'},
+        {name: 'content', type: 'json'},
         {name: 'created_at', type: 'datetime'},
         {name: 'updated_at', type: 'datetime'}
       ]
@@ -121,6 +123,7 @@ module.exports = (function(Nodal) {
       expect(obj).to.have.ownProperty('id');
       expect(obj).to.have.ownProperty('name');
       expect(obj).to.have.ownProperty('age');
+      expect(obj).to.have.ownProperty('content');
       expect(obj).to.have.ownProperty('created_at');
       expect(obj).to.have.ownProperty('updated_at');
 
@@ -129,6 +132,7 @@ module.exports = (function(Nodal) {
       expect(obj).to.have.ownProperty('id');
       expect(obj).to.have.ownProperty('name');
       expect(obj).to.not.have.ownProperty('age');
+      expect(obj).to.not.have.ownProperty('content');
       expect(obj).to.not.have.ownProperty('created_at');
       expect(obj).to.not.have.ownProperty('updated_at');
 
@@ -137,6 +141,7 @@ module.exports = (function(Nodal) {
       expect(obj).to.not.have.ownProperty('id');
       expect(obj).to.not.have.ownProperty('name');
       expect(obj).to.have.ownProperty('age');
+      expect(obj).to.have.ownProperty('content');
       expect(obj).to.have.ownProperty('created_at');
       expect(obj).to.have.ownProperty('updated_at');
 
@@ -154,12 +159,14 @@ module.exports = (function(Nodal) {
       expect(obj).to.have.ownProperty('id');
       expect(obj).to.have.ownProperty('name');
       expect(obj).to.have.ownProperty('age');
+      expect(obj).to.have.ownProperty('content');
       expect(obj).to.have.ownProperty('created_at');
       expect(obj).to.have.ownProperty('updated_at');
       expect(obj).to.have.ownProperty('house');
       expect(obj.house).to.have.ownProperty('id');
       expect(obj.house).to.have.ownProperty('material');
       expect(obj.house).to.have.ownProperty('color');
+      expect(obj.house).to.have.ownProperty('content');
       expect(obj.house).to.have.ownProperty('created_at');
       expect(obj.house).to.have.ownProperty('updated_at');
 
@@ -168,6 +175,7 @@ module.exports = (function(Nodal) {
       expect(obj).to.have.ownProperty('id');
       expect(obj).to.have.ownProperty('name');
       expect(obj).to.not.have.ownProperty('age');
+      expect(obj).to.not.have.ownProperty('content');
       expect(obj).to.not.have.ownProperty('created_at');
       expect(obj).to.not.have.ownProperty('updated_at');
       expect(obj).to.not.have.ownProperty('house');
@@ -177,12 +185,14 @@ module.exports = (function(Nodal) {
       expect(obj).to.have.ownProperty('id');
       expect(obj).to.have.ownProperty('name');
       expect(obj).to.not.have.ownProperty('age');
+      expect(obj).to.not.have.ownProperty('content');
       expect(obj).to.not.have.ownProperty('created_at');
       expect(obj).to.not.have.ownProperty('updated_at');
       expect(obj).to.have.ownProperty('house');
       expect(obj.house).to.have.ownProperty('id');
       expect(obj.house).to.have.ownProperty('material');
       expect(obj.house).to.have.ownProperty('color');
+      expect(obj.house).to.have.ownProperty('content');
       expect(obj.house).to.have.ownProperty('created_at');
       expect(obj.house).to.have.ownProperty('updated_at');
 
@@ -191,12 +201,14 @@ module.exports = (function(Nodal) {
       expect(obj).to.have.ownProperty('id');
       expect(obj).to.have.ownProperty('name');
       expect(obj).to.not.have.ownProperty('age');
+      expect(obj).to.not.have.ownProperty('content');
       expect(obj).to.not.have.ownProperty('created_at');
       expect(obj).to.not.have.ownProperty('updated_at');
       expect(obj).to.have.ownProperty('house');
       expect(obj.house).to.have.ownProperty('id');
       expect(obj.house).to.have.ownProperty('material');
       expect(obj.house).to.not.have.ownProperty('color');
+      expect(obj.house).to.not.have.ownProperty('content');
       expect(obj.house).to.not.have.ownProperty('created_at');
       expect(obj.house).to.not.have.ownProperty('updated_at');
 
@@ -205,12 +217,14 @@ module.exports = (function(Nodal) {
       expect(obj).to.not.have.ownProperty('id');
       expect(obj).to.not.have.ownProperty('name');
       expect(obj).to.have.ownProperty('age');
+      expect(obj).to.have.ownProperty('content');
       expect(obj).to.have.ownProperty('created_at');
       expect(obj).to.have.ownProperty('updated_at');
       expect(obj).to.have.ownProperty('house');
       expect(obj.house).to.have.ownProperty('id');
       expect(obj.house).to.have.ownProperty('material');
       expect(obj.house).to.have.ownProperty('color');
+      expect(obj.house).to.have.ownProperty('content');
       expect(obj.house).to.have.ownProperty('created_at');
       expect(obj.house).to.have.ownProperty('updated_at');
 
@@ -219,6 +233,7 @@ module.exports = (function(Nodal) {
       expect(obj).to.not.have.ownProperty('id');
       expect(obj).to.not.have.ownProperty('name');
       expect(obj).to.have.ownProperty('age');
+      expect(obj).to.have.ownProperty('content');
       expect(obj).to.have.ownProperty('created_at');
       expect(obj).to.have.ownProperty('updated_at');
       expect(obj).to.not.have.ownProperty('house');
@@ -228,12 +243,14 @@ module.exports = (function(Nodal) {
       expect(obj).to.not.have.ownProperty('id');
       expect(obj).to.not.have.ownProperty('name');
       expect(obj).to.have.ownProperty('age');
+      expect(obj).to.have.ownProperty('content');
       expect(obj).to.have.ownProperty('created_at');
       expect(obj).to.have.ownProperty('updated_at');
       expect(obj).to.have.ownProperty('house');
       expect(obj.house).to.not.have.ownProperty('id');
       expect(obj.house).to.not.have.ownProperty('material');
       expect(obj.house).to.have.ownProperty('color');
+      expect(obj.house).to.have.ownProperty('content');
       expect(obj.house).to.have.ownProperty('created_at');
       expect(obj.house).to.have.ownProperty('updated_at');
 
@@ -249,6 +266,7 @@ module.exports = (function(Nodal) {
       expect(obj[0]).to.have.ownProperty('id');
       expect(obj[0]).to.have.ownProperty('name');
       expect(obj[0]).to.not.have.ownProperty('age');
+      expect(obj[0]).to.not.have.ownProperty('content');
       expect(obj[0]).to.not.have.ownProperty('created_at');
       expect(obj[0]).to.not.have.ownProperty('updated_at');
 
@@ -256,6 +274,7 @@ module.exports = (function(Nodal) {
       expect(obj[0]).to.not.have.ownProperty('id');
       expect(obj[0]).to.not.have.ownProperty('name');
       expect(obj[0]).to.have.ownProperty('age');
+      expect(obj[0]).to.have.ownProperty('content');
       expect(obj[0]).to.have.ownProperty('created_at');
       expect(obj[0]).to.have.ownProperty('updated_at');
 


### PR DESCRIPTION
This commit has the initial JSONB support for postgres. It includes

*  `__json` and `__jsoncontains` comparators
*  Composer tests for JSON columns and comparators
*  Updates to LEARN.md detailing usage

Fixes #81 