### PR TITLE
Fix DummyTask exec params

### DIFF
--- a/src/tasks/dummy_task.js
+++ b/src/tasks/dummy_task.js
@@ -6,7 +6,7 @@ module.exports = (function() {
 
   class DummyTask extends Nodal.SchedulerTask {
 
-    exec(app, callback) {
+    exec(app, args, callback) {
 
       console.log('Dummy task executed');
       callback();


### PR DESCRIPTION
Back in fb7fe261 we changed the core/required/sceduler.js to send 3 params to tasks: app, args and callback. Dummy task was never updated