### PR TITLE
Migration createTable always generates properties

### DIFF
--- a/core/required/db/schema_generator.js
+++ b/core/required/db/schema_generator.js
@@ -66,11 +66,7 @@ module.exports = (function() {
         }
       });
 
-      if (Object.keys(newProperties).length) {
-        columnData.properties = newProperties;
-      } else {
-        delete columnData.properties;
-      }
+      columnData.properties = newProperties;
 
       return columnData;
 


### PR DESCRIPTION
Per conversation in #124, this PR always ensures that `properties` are added to schema on createTable as they are with addColumn for consistency

Fixes #124 