### PR TITLE
Refactor Tasks

### DIFF
--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -50,6 +50,13 @@ module.exports = (function() {
           message: 'Database name',
           when: (answers) => answers.database
         },
+        {
+          name: 'scheduler',
+          type: 'confirm',
+          default: false,
+          message: 'Task Scheduler?',
+        },
+
       ];
 
       inquirer.prompt(questions, (promptResult) => {
@@ -115,10 +122,22 @@ module.exports = (function() {
           // Lets enable database support by default if the user said yes to the prompt
           // NOTE: I didnt see the need to templatize this since it was quicker to re-write
           //       the copied in file
-          if (promptResult.database) {
+          if (promptResult.database || promptResult.scheduler) {
             const appFile = './' + dirname + '/app/app.js';
             let contents = fs.readFileSync(appFile).toString()
-            fs.writeFileSync(appFile, contents.replace(/\/\/ /g, ''));
+
+            // Uncomment DB in app/app,.js
+            if (promptResult.database) {
+              contents = contents.replace(/\/\/ const db/g, 'const db')
+              contents = contents.replace(/\/\/ this.useDat/g, 'this.useDat')
+            }
+
+            // Uncomment Scheduler in app/app,.js
+            if (promptResult.scheduler) {
+              contents = contents.replace(/\/\/ const sch/g, 'const sch')
+              contents = contents.replace(/\/\/ this.useSch/g, 'this.useSch')
+            }
+            fs.writeFileSync(appFile, contents);
           }
 
           let spawn = require('cross-spawn-async');

--- a/cli/interface/generate/templates/task.jst
+++ b/cli/interface/generate/templates/task.jst
@@ -4,7 +4,7 @@ module.exports = (function() {
 
   const Nodal = require('nodal');
 
-  class {{= data.name }}Task {
+  class {{= data.name }}Task extends Nodal.Task {
 
     exec(app, args, callback) {
 

--- a/core/module.js
+++ b/core/module.js
@@ -170,7 +170,13 @@ module.exports = (function() {
         return Nodal.SchemaGenerator || (Nodal.SchemaGenerator = require('./required/db/schema_generator.js'));
       },
       enumerable: true
-    }
+    },
+    Task: {
+      get: function() {
+        return Nodal.Task || (Nodal.Task = require('./required/task.js'));
+      },
+      enumerable: true
+    },
   });
 
   Object.defineProperties(LazyNodal.my, {

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -19,6 +19,10 @@ module.exports = (function() {
   /* Import Database */
   // const db = Nodal.require('db/main.js');
 
+  /* Import Scheduler */
+  // const scheduler = Nodal.require('schedulers/main.js');
+
+
   class App extends Nodal.Application {
 
     __setup__() {
@@ -37,6 +41,10 @@ module.exports = (function() {
 
       /* Database */
       // this.useDatabase(db, 'main');
+
+      /* Scheduler */
+      // this.useScheduler(scheduler);
+
 
     }
 

--- a/src/schedulers/main.js
+++ b/src/schedulers/main.js
@@ -5,9 +5,18 @@ module.exports = (function() {
   const Nodal = require('nodal');
   const scheduler = new Nodal.Scheduler();
 
+  /* generator: begin imports */
+
   const DummyTask = Nodal.require('tasks/dummy_task.js');
 
+  /* generator: end imports */
+
+  /* generator: begin tasks */
+
   scheduler.minutely(30).perform(DummyTask);
+
+  /* generator: end tasks */
+
 
   return scheduler;
 

--- a/src/tasks/dummy_task.js
+++ b/src/tasks/dummy_task.js
@@ -4,7 +4,7 @@ module.exports = (function() {
 
   const Nodal = require('nodal');
 
-  class DummyTask extends Nodal.SchedulerTask {
+  class DummyTask extends Nodal.Task {
 
     exec(app, callback) {
 

--- a/src/tasks/dummy_task.js
+++ b/src/tasks/dummy_task.js
@@ -6,7 +6,7 @@ module.exports = (function() {
 
   class DummyTask extends Nodal.Task {
 
-    exec(app, callback) {
+    exec(app, args, callback) {
 
       console.log('Dummy task executed');
       callback();


### PR DESCRIPTION
PR Includes
* Drop ScheduledTask and just have `Nodal.Task` that can be scheduled or run one off
* Add flags to `nodal new g:task` to take optional schedule information
* Flag could be like `nodal new g:task --schedule:5m`. Maybe support s, m, h, d and w for durations. This would **add** to ./schedulers/main.js`
* Add (like with router)  `/* generator: begin tasks */` and `* generator: end tasks */` to `./schedulers/main.js` so that we can automatically add them when `g:task` is run with scheduler info
* Add (commented out) the default generated scheduler to `app/app.js` so that someone can quickly uncomment it to get scheduled tasks in the app thread
* Add a flag to `nodal new` to uncomment the commented out scheduler in `app/app.js` like we do with database now

closes #75