### PR TITLE
Adds Nodal version to CLI and Startup

### DIFF
--- a/cli/commands/version.js
+++ b/cli/commands/version.js
@@ -1,0 +1,22 @@
+module.exports = (() => {
+
+  'use strict';
+
+  const Command = require('../command.js');
+  const colors = require('colors/safe');
+
+  return new Command(
+    null,
+    'version',
+    {definition: 'Show Nodal version', hidden: false, order: 2},
+    (args, flags, callback) => {
+
+      let version = require('../../package.json').version;
+
+      console.log(colors.green.bold('Nodal Version: ') + version);
+
+      callback(null);
+
+  });
+
+})();

--- a/core/required/application.js
+++ b/core/required/application.js
@@ -591,7 +591,9 @@ module.exports = (function() {
 
       this.server = server;
 
-      console.log('Nodal HTTP server listening on port ' + port);
+      let version = require('../../package.json').version;
+
+      console.log(`Nodal ${version} HTTP server listening on port ${port}`);
 
       return true;
 


### PR DESCRIPTION
This PR is primarily to aid is debugging issues. It adds the following

* Adds `nodal version` command to the cli to render the version from package.json. This will help greatly is issue reporting 

* Adds nodal version from package.json to the server so that when you start your apps it will show the current nodal version. Example:  `Nodal 0.5.8-rc3 HTTP server listening on port 3000`