### PR TITLE
Update Readme and Learn

### DIFF
--- a/LEARN.md
+++ b/LEARN.md
@@ -112,8 +112,8 @@ module.exports = (function() {
 
   /* generator: end imports */
 
-  router.route(/^\/?$/, IndexController);
-  router.route(/^\/static\/(.*)/, StaticController);
+  router.route('/', IndexController);
+  router.route('/static/*', StaticController);
 
   /* generator: begin routes */
 
@@ -165,7 +165,6 @@ module.exports = (function() {
         this.app.template('index.html').generate(
           this.params,
           {
-            test: this.params.query.test,
             name: 'My Nodal Application'
           }
         )

--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ class IndexController extends Nodal.Controller {
       this.app.template('index.html').generate(
         this.params,
         {
-          test: this.params.query.test,
           name: 'My Nodal Application'
         }
       )
@@ -161,7 +160,7 @@ class BlogPostsController extends Nodal.Controller {
 
   show() {
 
-    BlogPost.find(params.id, (err, blogPost) => this.respond(err || blogPost));
+    BlogPost.find(this.params.route.id, (err, blogPost) => this.respond(err || blogPost));
 
   }
 
@@ -173,13 +172,13 @@ class BlogPostsController extends Nodal.Controller {
 
   update() {
 
-    BlogPost.update(params.id, params.body.data, (err, blogPost) => this.respond(err || blogPost));
+    BlogPost.update(this.params.route.id, params.body.data, (err, blogPost) => this.respond(err || blogPost));
 
   }
 
   destroy() {
 
-    BlogPost.destroy(params.id, (err, blogPost) => this.respond(err || blogPost));
+    BlogPost.destroy(this.params.route.id, (err, blogPost) => this.respond(err || blogPost));
 
   }
 


### PR DESCRIPTION
Updates the README.md and LEARN.md to 

* Use the new non regex router
* Update controller shows to use `this.params.route.id`
* Drop all the test references since we remove that from the default index long ago