### PR TITLE
Add version to output of nodal new

### DIFF
--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -11,9 +11,10 @@ module.exports = (function() {
   return {
     new: function(args, flags, callback) {
       const rootPath = path.resolve(__dirname);
+      const version = require('../../../package.json').version;
 
       console.log('');
-      console.log(`Welcome to ${colors.bold.green('Nodal!')}`);
+      console.log(`Welcome to ${colors.bold.green('Nodal! v' + version)}`);
       console.log('');
       console.log('Let\'s get some information about your project...');
       console.log('');


### PR DESCRIPTION
Since we have it in other places and to help debug issues when there are older version installed globally, this PR simply added the current version from package.json to the output of nodal new