### PR TITLE
Show Error for invalid column types on g:model

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@
 
 ### Bugs
 * :white_check_mark: Generator type checking (#138)
-* :x: `nodal db:bootstrap` throwing an error when there is no migrations (#141)
+* :white_check_mark: `nodal db:bootstrap` throwing an error when there is no migrations (#141)
 
 ### 1.0, Target: Q2 2016
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@
 * :hourglass: Docker integration
 
 ### Bugs
-* :x: Generator type checking (#138)
+* :white_check_mark: Generator type checking (#138)
 * :x: `nodal db:bootstrap` throwing an error when there is no migrations (#141)
 
 ### 1.0, Target: Q2 2016

--- a/cli/interface/generate/model.js
+++ b/cli/interface/generate/model.js
@@ -58,11 +58,11 @@ module.exports = (function() {
 
     return argList.slice(1).map(function(v) {
 
-      if (Object.keys(db.adapter.types).indexOf(v[1]) == -1) {
+      if (Object.keys(db.adapter.types).indexOf(v[1].toLowerCase()) == -1) {
         throw new Error(`Un-supported column type ${colors.yellow.bold(v[1])} for field ${colors.yellow.bold(v[0])}`);
       }
 
-      let obj = {name: inflect.underscore(v[0]), type: v[1]};
+      let obj = {name: inflect.underscore(v[0]), type: v[1].toLowerCase()};
       let rest = v.slice(2);
       let properties = {};
 

--- a/cli/interface/generate/model.js
+++ b/cli/interface/generate/model.js
@@ -53,7 +53,14 @@ module.exports = (function() {
 
   function convertArgListToPropertyList(argList) {
 
+    // Instantiate Database so we can get access to the Adapater types
+    let db = new Database();
+
     return argList.slice(1).map(function(v) {
+
+      if (Object.keys(db.adapter.types).indexOf(v[1]) == -1) {
+        throw new Error(`Un-supported column type ${colors.yellow.bold(v[1])} for field ${colors.yellow.bold(v[0])}`);
+      }
 
       let obj = {name: inflect.underscore(v[0]), type: v[1]};
       let rest = v.slice(2);


### PR DESCRIPTION
This PR changes `cli/interface/generate/model.js` to check the types for each column against the adapters type object. If any of the types listed for a column are invalid, nodal with throw an error indicating the column name and invalid type

Fixes #138 