### PR TITLE
Allow optional params to be passed onto ExecutionQueue

### DIFF
--- a/core/required/execution_queue.js
+++ b/core/required/execution_queue.js
@@ -16,12 +16,18 @@ module.exports = (function() {
 
     /**
     * Tell the manager to put an object in the queue.
-    * @param {Object} itemConstructor The item constructor (must have exec function) you wish to add to the queue.
+    * @param {Object} arguments The item constructor (must have exec function) plus other arguments you wish to add to the queue.
     */
-    use(itemConstructor) {
+    use() {
 
-      let item = new itemConstructor();
-      this._queue.push(item);
+      let args = [].slice.call(arguments);
+
+      if (args.length) {
+        let itemConstructor = args[0];
+        let item = new (itemConstructor.bind.apply(itemConstructor, args))();
+
+        this._queue.push(item);
+      }
 
     }
 

--- a/test/tests/execution_queue.js
+++ b/test/tests/execution_queue.js
@@ -1,0 +1,64 @@
+module.exports = (function(Nodal) {
+
+  'use strict';
+
+  const async = require('async');
+
+  let expect = require('chai').expect;
+
+  describe('Execution Queue', function() {
+
+    class TestableMiddleware {
+
+      constructor(option1, option2, option3) {
+        this.option1 = option1;
+        this.option2 = option2;
+        this.option3 = option3;
+      }
+
+      exec(controller, callback) {
+        callback(null);
+      }
+
+    }
+
+    it('should let props get passed to Middleware', () => {
+      let app = new Nodal.Application();
+
+      app.middleware.use(TestableMiddleware, 'cats', 'dogs')
+
+      expect(app.middleware._queue[0].option1).to.equal('cats')
+      expect(app.middleware._queue[0].option2).to.equal('dogs')
+      expect(app.middleware._queue[0].option3).to.not.exist
+
+
+    });
+
+    it('should let still function if no props get passed to Middleware', () => {
+      let app = new Nodal.Application();
+
+      app.middleware.use(TestableMiddleware)
+
+      expect(app.middleware._queue[0].option1).to.not.exist
+      expect(app.middleware._queue[0].option2).to.not.exist
+      expect(app.middleware._queue[0].option3).to.not.exist
+
+
+    });
+
+    it('should let objects get passed to Middleware', () => {
+      let app = new Nodal.Application();
+
+      app.middleware.use(TestableMiddleware, { name: 'cat', type: 'feline' })
+
+      expect(app.middleware._queue[0].option1).to.exist
+      expect(app.middleware._queue[0].option1.name).to.equal('cat')
+      expect(app.middleware._queue[0].option2).to.not.exist
+      expect(app.middleware._queue[0].option3).to.not.exist
+
+    });
+
+
+  });
+
+});


### PR DESCRIPTION
This PR allows for options to be passed to Initializer, Middleware and Renderware

Please see detail in https://github.com/keithwhor/nodal/issues/146

Closes #146 