### PR TITLE
Update db/schema.json when model is first generated.

### DIFF
--- a/cli/interface/generate/model.js
+++ b/cli/interface/generate/model.js
@@ -142,6 +142,16 @@ module.exports = (function() {
 
       console.log(colors.green.bold('Create: ') + createPath);
 
+      filename = 'db/schema.json';
+      filename = process.cwd() + '/' + filename;
+      schemaObjects = JSON.parse(fs.readFileSync(filename));
+
+      schemaObjects.models[modelName] = schemaObject;
+
+      fs.writeFileSync(filename, schemaObjects);
+
+      console.log(colors.green.bold('Update: ') + filename);
+
       generateMigration('Create' + modelName,
         ['this.createTable(\"' + schemaObject.table + '\", ' + JSON.stringify(schemaObject.columns) + ')'],
         ['this.dropTable(\"' + schemaObject.table + '\")']


### PR DESCRIPTION
First, I wanna say you did a fantastic job on Nodal!

This PR is just to give you an idea... it's untested and it would be better to use SchemaGenerator to do the actual work, but I didn't want to take this too far until you had a chance to take a deeper look into issue #150.

Motivation:
The actual migration file (in db/migrations) is created when the model is generated, so I think the schema (db/schema.json) should be updated at that time also. This change in order of events, I think, is more logical and would enable us to run nodal in a virtual environment like vagrant or docker. Currently, after running ```nodal g:model --user``` the project is in a broken state until you run the migration (which updates db/schema.json).