### PR TITLE
Overwrite and Override Output Directory for `nodal new`

### DIFF
--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -13,12 +13,13 @@ module.exports = (function() {
       const rootPath = path.resolve(__dirname);
       const version = require('../../../package.json').version;
 
+      let overrideOutputPath = args.length ? args[0][0] : undefined;
+
       console.log('');
       console.log(`Welcome to ${colors.bold.green('Nodal! v' + version)}`);
       console.log('');
       console.log('Let\'s get some information about your project...');
       console.log('');
-
       var questions = [
         {
           name: 'name',
@@ -30,10 +31,13 @@ module.exports = (function() {
           name: 'overwrite',
           type: 'confirm',
           default: false,
-          message: 'Directory exists, overwrite?',
+          message: (answers) => {
+            let dirname = overrideOutputPath || `./${answers.name.replace(/[^A-Za-z0-9-_]/gi, '-').toLowerCase()}`;
+            return `Output directory '${dirname}' exists. Overwrite?`;
+          },
           when: (answers) => {
-            let dirname = answers.name.replace(/[^A-Za-z0-9-_]/gi, '-').toLowerCase();
-            return fs.existsSync('./' + dirname);
+            let dirname = overrideOutputPath || answers.name.replace(/[^A-Za-z0-9-_]/gi, '-').toLowerCase();
+            return fs.existsSync(`./${dirname}`);
           }
         },
         {
@@ -81,7 +85,8 @@ module.exports = (function() {
 
         promptResult.version = require('../../../package.json').version;
 
-        let dirname = promptResult.name.replace(/[^A-Za-z0-9-_]/gi, '-').toLowerCase();
+        let appdirname = promptResult.name.replace(/[^A-Za-z0-9-_]/gi, '-').toLowerCase();
+        let dirname = overrideOutputPath || appdirname;
 
         console.log('');
         console.log('Creating directory "' + dirname + '"...');

--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -27,6 +27,16 @@ module.exports = (function() {
           message: 'Name',
         },
         {
+          name: 'overwrite',
+          type: 'confirm',
+          default: false,
+          message: 'Directory exists, overwrite?',
+          when: (answers) => {
+            let dirname = answers.name.replace(/[^A-Za-z0-9-_]/gi, '-').toLowerCase();
+            return fs.existsSync('./' + dirname);
+          }
+        },
+        {
           name: 'author',
           type: 'input',
           default: 'mysterious author',
@@ -77,10 +87,14 @@ module.exports = (function() {
         console.log('Creating directory "' + dirname + '"...');
         console.log('');
 
+        // If the target directory exists and we are not overwriting it, error
         if (fs.existsSync('./' + dirname)) {
-          callback(new Error('Directory "' + dirname + '" already exists, try a different project name'));
+            if ( !promptResult.overwrite ) {
+              callback(new Error('Directory "' + dirname + '" already exists, try a different project name'));
+            }
+        } else {
+          fs.mkdirSync('./' + dirname);
         }
-        fs.mkdirSync('./' + dirname);
 
         console.log('Copying Nodal directory structure and files...');
         console.log('');


### PR DESCRIPTION
This PR allows an argument to be optionally passed to overwrite the output location of `nodal new`. If the directory already exists, it will prompt the user if they wish to overwrite this output directory

**NOTE:** Overwrite just copies ontop