### PR TITLE
default project name as first parameter

### DIFF
--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -23,7 +23,7 @@ module.exports = (function() {
         {
           name: 'name',
           type: 'input',
-          default: 'my-nodal-project',
+          default: args[0] || 'my-nodal-project',
           message: 'Name',
         },
         {

--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -19,11 +19,13 @@ module.exports = (function() {
       console.log('Let\'s get some information about your project...');
       console.log('');
 
+      debugger;
+
       var questions = [
         {
           name: 'name',
           type: 'input',
-          default: args[0] || 'my-nodal-project',
+          default: args[0][0] || 'my-nodal-project',
           message: 'Name',
         },
         {


### PR DESCRIPTION
The first parameter in `new` command will be used as default project name.

Example
![image](https://cloud.githubusercontent.com/assets/6811076/12876286/4c1f509e-cde6-11e5-8c01-7f2e5d30c53a.png)
