### PR TITLE
use first parameter as default project name

### DIFF
--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -23,7 +23,7 @@ module.exports = (function() {
         {
           name: 'name',
           type: 'input',
-          default: 'my-nodal-project',
+          default: args[0] ? args[0][0] : 'my-nodal-project',
           message: 'Name',
         },
         {


### PR DESCRIPTION
As mentioned in #162 I'm resubmitting this commit. 

Obs: I had to change from:
`args[0][0] || 'my-nodal-project' ` 
to 
`args[0] ? args[0][0] : 'my-nodal-project'` 
in case no parameter is passed to `new` command.  