### PR TITLE
This removes the Error: undefined on Windows 10.

### DIFF
--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -113,7 +113,10 @@ module.exports = (function() {
               return (callback) => {
 
                 console.log(`Copying ${m}...`);
-                fs.copy(`${rootPath}/../../../${m}`, `./${dirname}/node_modules/nodal/${m}`, callback);
+                fs.copy(
+                      path.join(rootPath, '..','..','..', m),
+                      path.join('.', 'dirname', 'node_modules', 'nodal', m),
+                      callback);
 
               };
             }),

--- a/cli/interface/generate/new.js
+++ b/cli/interface/generate/new.js
@@ -115,7 +115,7 @@ module.exports = (function() {
                 console.log(`Copying ${m}...`);
                 fs.copy(
                       path.join(rootPath, '..','..','..', m),
-                      path.join('.', 'dirname', 'node_modules', 'nodal', m),
+                      path.join(process.cwd(), dirname, 'node_modules', 'nodal', m),
                       callback);
 
               };


### PR DESCRIPTION
Sometimes Windows handles the path separator, sometimes it doesn't.

Fixes: https://github.com/keithwhor/nodal/issues/166