### PR TITLE
FIX: Schema Generation when multiple index

### DIFF
--- a/core/required/db/schema_generator.js
+++ b/core/required/db/schema_generator.js
@@ -385,7 +385,7 @@ module.exports = (function() {
                   ].filter(function(v) { return !!v; }).join(', '),
                 '}',
               ].join('');
-            }).join('\n'),
+            }).join(',\n'),
           '  ]' + (hasModels ? ',' : ''),
         ]);
 


### PR DESCRIPTION
If your database has multiple index's defined `this.createIndex(...)`, schema generator was not delimiting them with a `,` and thus generating invalid json and an error