### PR TITLE
Log error when attempting to parse JSON Body

### DIFF
--- a/core/required/router.js
+++ b/core/required/router.js
@@ -107,6 +107,7 @@ module.exports = (() => {
           try {
             return JSON.parse(body);
           } catch(e) {
+            console.log("Failed to parse JSON Body", e);
             return {};
           }
         }


### PR DESCRIPTION
I noticed when testing some APIs with model validation, if invalid json is sent, no error is reported. This PR is a quick fix to log to the console on the catch if nodal fails to parse the json body