### PR TITLE
Auto populate params.auth with access token details

### DIFF
--- a/cli/interface/generate/templates/models/access_token.jst
+++ b/cli/interface/generate/templates/models/access_token.jst
@@ -63,7 +63,7 @@ module.exports = (function() {
       this.query()
         .join('user')
         .where({
-          access_token: params.query.access_token,
+          access_token: params.auth.access_token,
           expires_at__gte: new Date()
         })
         .end((err, accessTokens) => {

--- a/core/required/router.js
+++ b/core/required/router.js
@@ -154,6 +154,26 @@ module.exports = (() => {
 
     }
 
+    parseAuth(params, headers) {
+
+      let auth = {};
+
+      if (params.access_token) {
+        auth.token_type = 'bearer';
+        auth.access_token = params.access_token || '';
+      }
+
+      if (headers['authorization']) {
+        let parts = headers['authorization'].split(' ');
+        if (parts.length === 2 && /^Bearer$/i.test(parts[0])) {
+            auth.token_type = 'bearer';
+            auth.access_token = parts[1];
+        }
+      }
+
+      return auth;
+    }
+
     prepare(ip, url, method, headers, body) {
 
       let path = this.parsePath(url);
@@ -181,6 +201,7 @@ module.exports = (() => {
         query: new StrongParam(this.parseQueryParameters(url.parse(routeData.url, true).query)),
         body: new StrongParam(this.parseBody(routeData.body, routeData.headers)),
         path: routeData.path,
+        auth: this.parseAuth(url.parse(routeData.url, true).query, routeData.headers),
         matches: routeData.matches,
         route: routeData.route,
         remoteAddress: routeData.headers['x-forwarded-for'] || routeData.remoteAddress,


### PR DESCRIPTION
This PR Fixe #125 and creates an `auth` object on the params passed to controllers that has the `access_token` auto populated from either the `access_token` query param or the `authorization` header of the request. This occurs in the router dispatch

In `access_token#verify` method, you can use `params.auth.access_token` to retrieve the token. 

**NOTE: ** While not added to the query `params.auth.token_type` is also pre-populated with `bearer`