### PR TITLE
Allow env.PORT to be used in Dev and Test

### DIFF
--- a/src/config/secrets.json
+++ b/src/config/secrets.json
@@ -1,11 +1,11 @@
 {
 
   "development": {
-    "port": 3000
+    "port": "{{= env.PORT || 3000 }}"
   },
 
   "test": {
-    "port": 3000
+    "port":  "{{= env.PORT || 3000 }}"
   },
 
   "production": {


### PR DESCRIPTION
I needed to be able to override the port used in dev from 3000 to something as I had another nodal app in dev mode running as well

This teeny PR allows the PORT env to be used with a fallback to 3000 so that I can `env PORT=4444 nodal s`  (I use fish shell) and run the app

NOTE: Only applies to new apps since this change is in the src/tree

