### PR TITLE
Create database in bootstrap call

### DIFF
--- a/core/my/bootstrapper.js
+++ b/core/my/bootstrapper.js
@@ -279,6 +279,7 @@ module.exports = (() => {
     bootstrap(callback) {
 
       async.series([
+        (cb) => this.create(cb),
         (cb) => this.prepare(cb),
         (cb) => this.migrate(0, cb),
         (cb) => this.seed(cb)

--- a/core/required/controller.js
+++ b/core/required/controller.js
@@ -139,15 +139,26 @@ module.exports = (() => {
     }
 
     /**
+    * Uppercase all words in header key.
+    * @param {String} key
+    * @return {String}
+    */
+    updateHeaderKey(key){
+      key = key.split('-').map(function(v) {
+        return v[0].toUpperCase() + v.substr(1).toLowerCase();
+      }).join('-');
+
+      return key;
+    }
+
+    /**
     * Set a specific response header
     * @param {String} key
     * @param {String} value
     */
     setHeader(key, value) {
 
-      key = key.split('-').map(function(v) {
-        return v[0].toUpperCase() + v.substr(1).toLowerCase();
-      }).join('-');
+      key = this.updateHeaderKey(key);
 
       if (key === 'Content-Type' && value.indexOf(';') === -1 && (
         value === 'application/javascript' ||
@@ -162,14 +173,24 @@ module.exports = (() => {
     }
 
     /**
+     * Add a value to a existing specific response header. If header not exists create it.
+     * @param {String} key
+     * @param {String} value
+     */
+    appendToHeader(key, value){
+      key = this.updateHeaderKey(key);
+
+      return this._headers[key] ? this._headers[key] += ', ' + value :  this.setHeader(key, value);
+    }
+
+    /**
     * Get the value of a specific response header
     * @param {String} key
     * @param {String} value Default value returned if not found
     */
     getHeader(key, value) {
-      key = key.split('-').map(function(v) {
-        return v[0].toUpperCase() + v.substr(1).toLowerCase();
-      }).join('-');
+      key = this.updateHeaderKey(key);
+        
       return this._headers.hasOwnProperty(key) ? this._headers[key] : value;
     }
 

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -9,10 +9,12 @@ module.exports = (function() {
   /* executed *before* Controller-specific middleware */
 
   const CORSMiddleware = Nodal.require('middleware/cors_middleware.js');
+  // const CORSAuthorizationMiddleware = Nodal.require('middleware/cors_authorization_middleware.js');
   // const ForceWWWMiddleware = Nodal.require('middleware/force_www_middleware.js');
   // const ForceHTTPSMiddleware = Nodal.require('middleware/force_https_middleware.js');
 
   router.middleware.use(CORSMiddleware);
+  // router.middleware.use(CORSAuthorizationMiddleware);
   // router.middleware.use(ForceWWWMiddleware);
   // router.middleware.use(ForceHTTPSMiddleware);
 

--- a/src/middleware/cors_authorization_middleware.js
+++ b/src/middleware/cors_authorization_middleware.js
@@ -1,0 +1,21 @@
+module.exports = (function() {
+
+  'use strict';
+
+  const Nodal = require('nodal');
+
+  class CORSAuthorizationMiddleware {
+
+      exec(controller, callback) {
+
+          controller.allowOrigin('*');
+          controller.appendToHeader('Access-Control-Allow-Headers', 'Authorization');
+          callback(null);
+
+      }
+
+  }
+
+  return CORSAuthorizationMiddleware;
+
+})();


### PR DESCRIPTION
In the description of the command `nodal help` there is `nodal db:boostrap` described with `Runs db:create, db:prepare, db:migrate, db:seed`. If you try to run this there is an error because the database will not be created. This is because the `create` function is never called. I added the database creation to the bootstrap call.