### PR TITLE
Updates doc build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "test": "mocha ./test/runner.js",
-    "docs": "documentation core/module.js -o docs -f html"
+    "docs": "documentation build core/module.js -o docs -f html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Docs won't build until new node 6.0 issues are resolved since the documentation builder parses JS with `babylon` and throws errors on unwrapped empty arrow functions.
But this way once those fixes are in, docs should build fine after this PR is merged.

not working -> less not working
After node 6.0 fixes
less not working -> working.