### PR TITLE
Updates task CLI command to pass same number of arguments as scheduler

### DIFF
--- a/cli/commands/task.js
+++ b/cli/commands/task.js
@@ -35,7 +35,7 @@ module.exports = (() => {
       const Task = require(taskPath);
       let task = new Task();
 
-      task.exec(args.slice(1), (err) => {
+      task.exec(null, args.slice(1), (err) => {
 
         if (err) {
           console.log(`${colors.red.bold('Task Error:')} ${err.message}`);

--- a/cli/templates/task.jst
+++ b/cli/templates/task.jst
@@ -6,7 +6,7 @@ module.exports = (function() {
 
   class {{= data.name }}Task extends Nodal.Task {
 
-    exec(args, callback) {
+    exec(app, args, callback) {
 
       console.log('{{= data.name}} task executed');
       callback();

--- a/src/tasks/dummy_task.js
+++ b/src/tasks/dummy_task.js
@@ -6,7 +6,7 @@ module.exports = (function() {
 
   class DummyTask extends Nodal.Task {
 
-    exec(args, callback) {
+    exec(app, args, callback) {
 
       console.log('Dummy task executed');
       callback();


### PR DESCRIPTION
I found errors when I ran the task cli command because the task was being called with a different number of arguments than the scheduler was using.

Made a couple of small fixes to have a working task cli command again. Not sure if passing null as the app argument is the intended usage.

Feel free to merge if you want, since not sure what your plan was. If anything needs updating let me know.