### PR TITLE
Print Usage if Arguments are Not Provided

### DIFF
--- a/cli/bin.js
+++ b/cli/bin.js
@@ -3,4 +3,8 @@
 'use strict';
 
 const CLI = require('./cli.js');
-CLI.run(process.argv.slice(2));
+if (process.argv.length > 2) {
+  CLI.run(process.argv.slice(2));
+} else {
+  CLI.run(['help']);
+}


### PR DESCRIPTION
It displays stack trace if no args.
I think it's better to print help message.

```
$ nodal
/usr/local/lib/node_modules/nodal/node_modules/cmnd/lib/command_line_interface.js:22
      commands = commands.split(':');
                         ^

TypeError: Cannot read property 'split' of undefined
    at CommandLineInterface.parse (/usr/local/lib/node_modules/nodal/node_modules/cmnd/lib/command_line_interface.js:22:26)
    at CommandLineInterface.run (/usr/local/lib/node_modules/nodal/node_modules/cmnd/lib/command_line_interface.js:133:19)
    at Object.<anonymous> (/usr/local/lib/node_modules/nodal/cli/bin.js:6:5)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Function.Module.runMain (module.js:575:10)
    at startup (node.js:160:18)
```