### PR TITLE
Minor fix to new.js CLI to fix author param

### DIFF
--- a/cli/commands/new.js
+++ b/cli/commands/new.js
@@ -43,7 +43,7 @@ module.exports = (() => {
 
       let data = {
         name: args[0] ? (args[0] + '').replace(/_/g, ' ') : '',
-        author: vflags.author[0] ? (vflags.author[0] || '').replace(/_/g, ' ') || '' : '',
+        author: (vflags.author && v.flags.author[0] || '').replace(/_/g, ' ') || '',
         ignoreOutput: vflags.hasOwnProperty('ignore-output')
       };
 

--- a/cli/commands/new.js
+++ b/cli/commands/new.js
@@ -43,7 +43,7 @@ module.exports = (() => {
 
       let data = {
         name: args[0] ? (args[0] + '').replace(/_/g, ' ') : '',
-        author: (vflags.author || '').replace(/_/g, ' ') || '',
+        author: vflags.author[0] ? (vflags.author[0] || '').replace(/_/g, ' ') || '' : '',
         ignoreOutput: vflags.hasOwnProperty('ignore-output')
       };
 


### PR DESCRIPTION
When trying to automate Nodal install in docker, I found out that the --author param on "nodal new" wasn't working properly. Original version was trying to do a replace on an array (vflags.author comes out as an array, not a string.)

This should fix.