### PR TITLE
Fix the creation of test database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
 addons:
   postgresql: "9.4"
 before_script:
+  - psql -c 'create database nodal_test;' -U postgres
   - psql -c 'create database travis_ci_test;' -U postgres
 env: NODE_ENV=test

--- a/cli/commands/db/create.js
+++ b/cli/commands/db/create.js
@@ -23,7 +23,7 @@ module.exports = (() => {
     run(args, flags, vflags, callback) {
 
       const bootstrapper = require('../../../core/my/bootstrapper.js');
-      bootstrapper.create(callback);
+      bootstrapper.create(callback, vflags);
 
     }
 

--- a/cli/commands/db/drop.js
+++ b/cli/commands/db/drop.js
@@ -23,7 +23,7 @@ module.exports = (() => {
     run(args, flags, vflags, callback) {
 
       const bootstrapper = require('../../../core/my/bootstrapper.js');
-      bootstrapper.drop(callback);
+      bootstrapper.drop(callback, vflags);
 
     }
 

--- a/core/my/bootstrapper.js
+++ b/core/my/bootstrapper.js
@@ -19,8 +19,11 @@ module.exports = (() => {
 
     constructor() {
 
-      this.cfg = Config.db.main;
-      this.rootCfg = Object.create(this.cfg);
+      this.cfg = Config.db;
+      this.cfg.test = this.cfg.test.main;
+      this.cfg.development = this.cfg.development.main;
+      this.cfg.production = this.cfg.production.main;
+      this.rootCfg = Object.create(this.cfg.development);
       this.rootCfg.database = 'postgres';
 
     }
@@ -38,7 +41,7 @@ module.exports = (() => {
       let db = new Database();
 
       try {
-        db.connect(this.cfg);
+        db.connect(this.cfg.development);
       } catch (e) {
         return callback(e);
       }
@@ -47,15 +50,23 @@ module.exports = (() => {
 
     }
 
-    create(callback) {
+    create(callback, flags) {
 
-      this.rootDb().create(this.cfg.database, callback);
+      if (flags.test) {
+        this.rootDb().create(this.cfg.test.database, callback);
+      } else {
+        this.rootDb().create(this.cfg.development.database, callback);
+      }
 
     }
 
-    drop(callback) {
+    drop(callback, flags) {
 
-      this.rootDb().drop(this.cfg.database, callback);
+      if (flags.test) {
+        this.rootDb().drop(this.cfg.test.database, callback);
+      } else {
+        this.rootDb().drop(this.cfg.development.database, callback);
+      }
 
     }
 

--- a/core/my/config.js
+++ b/core/my/config.js
@@ -33,8 +33,8 @@ module.exports = (() => {
     } catch(e) {
       throw new Error(`Could not parse "config/${filename}": Invalid JSON`);
     }
-
-    config[path.basename(filename, ext)] = configData[env.name];
+    
+    config[path.basename(filename, ext)] = configData;
 
   });
 

--- a/test/tests/composer.js
+++ b/test/tests/composer.js
@@ -104,7 +104,7 @@ module.exports = (function(Nodal) {
 
     before(function(done) {
 
-      db.connect(Nodal.my.Config.db.main);
+      db.connect(Nodal.my.Config.db.development.main);
 
       db.transaction(
         [schemaParent, schemaFriendship, schemaChild, schemaPartner, schemaPet].map(schema => {

--- a/test/tests/database.js
+++ b/test/tests/database.js
@@ -51,7 +51,7 @@ module.exports = (function(Nodal) {
 
       it('should connect to my.Config database "main"', function() {
 
-        expect(db.connect(Nodal.my.Config.db.main)).to.equal(true);
+        expect(db.connect(Nodal.my.Config.db.development.main)).to.equal(true);
 
       });
 

--- a/test/tests/graph_query.js
+++ b/test/tests/graph_query.js
@@ -82,7 +82,7 @@ module.exports = Nodal => {
 
     before(function(done) {
 
-      db.connect(Nodal.my.Config.db.main);
+      db.connect(Nodal.my.Config.db.development.main);
 
       db.transaction(
         [schemaUser, schemaThread, schemaPost, schemaVote].map(schema => {

--- a/test/tests/model.js
+++ b/test/tests/model.js
@@ -85,7 +85,7 @@ module.exports = (function(Nodal) {
 
     before(function(done) {
 
-      db.connect(Nodal.my.Config.db.main);
+      db.connect(Nodal.my.Config.db.development.main);
 
       db.transaction(
         [schemaParent, schemaHouse].map(schema => {


### PR DESCRIPTION
Fix the creation of test database

Currently, support for creating test database is not supported, resulting in errors when writing unit tests. If the user enters `nodal db:create --test` in the command line, it will create the test database. Same goes for user dropping the database. User has to specify the `--test` flag to create the test database. Tested and working locally. Welcome to any feedback you might have. Cheers :)

close #264

Changed how tests connect to my.Config database "main"