### PR TITLE
Allow Header Overrides on Controller Tests

### DIFF
--- a/core/mocha/endpoint_request.js
+++ b/core/mocha/endpoint_request.js
@@ -23,7 +23,7 @@ class EndpointRequest {
         '::1',
         this.url,
         method,
-        headers,
+        Object.keys(headers || {}).reduce(function(accum, curr){ headers[curr.toLowerCase()] = headers[curr]; return headers;},{}),
         body
       ),
       (err, status, headers, body) => {
@@ -50,25 +50,25 @@ class EndpointRequest {
 
   }
 
-  get(headers, callback) {
+  get(callback, headers) {
 
     this.mock('GET', null, headers, callback);
 
   }
 
-  del(headers, callback) {
+  del(callback, headers) {
 
     this.mock('DELETE', null, headers, callback);
 
   }
 
-  post(body, headers, callback) {
+  post(body, callback, headers) {
 
     this.mock('POST', body, headers, callback);
 
   }
 
-  put(body, headers, callback) {
+  put(body, callback, headers) {
 
     this.mock('PUT', body, headers, callback);
 

--- a/core/mocha/endpoint_request.js
+++ b/core/mocha/endpoint_request.js
@@ -16,14 +16,14 @@ class EndpointRequest {
 
   }
 
-  mock(method, body, callback) {
+  mock(method, body, headers, callback) {
 
     return this.router.dispatch(
       this.router.prepare(
         '::1',
         this.url,
         method,
-        {},
+        headers,
         body
       ),
       (err, status, headers, body) => {
@@ -50,27 +50,27 @@ class EndpointRequest {
 
   }
 
-  get(callback) {
+  get(headers, callback) {
 
-    this.mock('GET', null, callback);
-
-  }
-
-  del(callback) {
-
-    this.mock('DELETE', null, callback);
+    this.mock('GET', null, headers, callback);
 
   }
 
-  post(body, callback) {
+  del(headers, callback) {
 
-    this.mock('POST', body, callback);
+    this.mock('DELETE', null, headers, callback);
 
   }
 
-  put(body, callback) {
+  post(body, headers, callback) {
 
-    this.mock('PUT', body, callback);
+    this.mock('POST', body, headers, callback);
+
+  }
+
+  put(body, headers, callback) {
+
+    this.mock('PUT', body, headers, callback);
 
   }
 


### PR DESCRIPTION
For issue #300:
1. I didn't see any existing controller tests using the `endpoint_request.js`. I'd be happy to write some if you want them
2. I added the headers options in as the last parameter, which is fugly, but I didn't want to break backward compatibility or documentation
