### PR TITLE
Fix Issue #310 Re: ModelArray#toObject

### DIFF
--- a/core/required/model_array.js
+++ b/core/required/model_array.js
@@ -44,7 +44,7 @@ class ModelArray extends ItemArray {
   */
   toObject(arrInterface) {
 
-    return this.map(m => m.toObject(arrInterface));
+    return Array.from( this ).map(m => m.toObject(arrInterface));
 
   }
 


### PR DESCRIPTION
Fix Fix problem where ModelArray#toObject returns a ModelArray rather than a standard Array. Issue: #310 