### PR TITLE
Update model Array.from

### DIFF
--- a/core/required/model_array.js
+++ b/core/required/model_array.js
@@ -25,18 +25,18 @@ class ModelArray extends ItemArray {
   * Convert a normal Array into a ModelArray
   * @param {Array} arr The array of child objects
   */
-  static from(arr) {
+  from(arr) {
 
-    if (!arr.length) {
-      throw new Error('Cannot create ModelArray from empty Array');
+    if (!arr) {
+      throw new Error('Cannot create ModelArray from empty Aray');
     }
-
-    let modelArray = new this(arr[0].constructor);
-    modelArray.push.apply(modelArray, arr);
-
-    return modelArray;
+    return arr.reduce((accum, model) =>
+      accum.concat(new this.Model(model))
+    , new ModelArray(this.model));
+    // return modelArray;
 
   }
+
 
   /**
   * Creates an Array of plain objects from the ModelArray, with properties matching an optional interface

--- a/core/required/model_array.js
+++ b/core/required/model_array.js
@@ -28,7 +28,7 @@ class ModelArray extends ItemArray {
   from(arr) {
 
     if (!arr) {
-      throw new Error('Cannot create ModelArray from empty Aray');
+      throw new Error('Cannot create ModelArray from empty Array');
     }
     return arr.reduce((accum, model) =>
       accum.concat(new this.Model(model))


### PR DESCRIPTION
Since the Array.from function previously would just build a Model array from the first element in the input array, it would require that the first element be a model, in order to make each element that same model. 
This refactor now changes it so that simply calling  
     new Nodal.ModelArray(Model).from(arr)
 will now return a model array of models with the input Model  Model