### PR TITLE
Invalid column name errors

### DIFF
--- a/core/required/composer.js
+++ b/core/required/composer.js
@@ -593,9 +593,11 @@ class Composer {
 
         if (rel) {
 
-          // if it's not found, return null...
-          if (!rel.getModel().hasColumn(column[0])) {
-            return null;
+          let model = rel.getModel();
+
+          // block out bad column names
+          if (!model.hasColumn(column[0])) {
+            throw new Error(`Column '${column[0]}' doesn't exist on '${model.name}'`);
           }
 
           table = rel.getModel().table();
@@ -608,7 +610,7 @@ class Composer {
 
         // block out bad column names
         if (!rel && !Model.hasColumn(columnName)) {
-          return null;
+          throw new Error(`Column '${columnName}' doesn't exist on '${this.Model.name}'`);
         }
 
         let value = comparisons[comparison];

--- a/test/tests/composer.js
+++ b/test/tests/composer.js
@@ -4,7 +4,7 @@ module.exports = Nodal => {
 
   const async = require('async');
 
-  let expect = require('chai').expect;
+  const { assert, expect } = require('chai');
 
   describe('Nodal.Composer', function() {
 
@@ -1225,7 +1225,7 @@ module.exports = Nodal => {
             children__is_favorite: true,
             children__license: null,
             pets__name: 'Oliver',
-            pets__alive: true,
+            pets__is_alive: true,
             name: 'Zoolander',
             pets__animal__in: ['Cat']
           },
@@ -1233,7 +1233,7 @@ module.exports = Nodal => {
             children__is_favorite: true,
             children__license__not_null: true,
             pets__name: 'Oliver',
-            pets__alive: true,
+            pets__is_alive: true,
             name: 'Zoolander',
             pets__animal__in: ['Cat']
           },
@@ -1241,7 +1241,7 @@ module.exports = Nodal => {
             careers__title: 'Freelancer',
             careers__is_active: true,
             pets__name: 'Oliver',
-            pets__alive: true,
+            pets__is_alive: true,
             name: 'Zoolander',
             pets__animal__in: ['Cat']
           },
@@ -1706,6 +1706,50 @@ module.exports = Nodal => {
           done();
 
         });
+
+    });
+
+    it('Should throw errors when querying with a bad column name', done => {
+
+      try {
+
+        Parent.query()
+          .join('pets')
+          .where({ active: true })
+          .end();
+
+        assert.fail("Expected query to throw an error");
+
+      } catch (error) {
+
+        expect(error.message).to.contain("Column 'active'");
+        expect(error.message).to.contain("'Parent'");
+
+      }
+
+      done();
+
+    });
+
+    it('Should throw errors when querying joins with a bad column name', done => {
+
+      try {
+
+        Parent.query()
+          .join('pets')
+          .where({ pets__active: true })
+          .end();
+
+        assert.fail("Expected query to throw an error");
+
+      } catch (error) {
+
+        expect(error.message).to.contain("Column 'active'");
+        expect(error.message).to.contain("'Pet'");
+
+      }
+
+      done();
 
     });
 


### PR DESCRIPTION
This PR will make the composer throw errors if a query tries to use invalid column names.

## Reasoning
Queries currently ignore invalid column names which makes it easy to write queries that break unexpectedly. 
This can lead to errors such as when a 'where' clause returns more records than it should. This change will ensure the developer is aware of a bad query and fix the issue.

## Example
- A model has fields like `author_id` and `is_admin`
- The developer writes a query like `Model.query().where({ user_id: user.id, is_admin: false }).destroyAll(...)`
- The developer made an easy mistake and used the column `user_id`. This doesn't exist on the model so Nodal silently ignores it. This query then selects and deletes *all* users by accident.
- This PR will fix issues like this by making a query like this throw an error to ensure this is never pushed to a deployed environment.